### PR TITLE
Jdk9+ Dependency Review

### DIFF
--- a/finish/ear/pom.xml
+++ b/finish/ear/pom.xml
@@ -55,14 +55,6 @@
             <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/start/ear/pom.xml
+++ b/start/ear/pom.xml
@@ -36,13 +36,6 @@
             <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- Support for JDK 9 and above -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Part of https://github.com/OpenLiberty/guides-common/issues/459

Successfully tested with `openjdk version "1.8.0_252"`
Successfully tested with `openjdk version "11.0.7"`