### PR TITLE
Upgrade liberty-maven-plugin to 3.7.1

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.7.1</version>
             </plugin>
             <!-- end::liberty-maven-plugin[] -->
         </plugins>


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

The dev mode output has been cleaned up a bit in the multi-mod dev mode case in LMP, so might as well take advantage.